### PR TITLE
remove is-windows dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "better-path-resolve": "^1.0.0",
     "graceful-fs": "^4.1.11",
-    "is-windows": "^1.0.0",
     "make-dir": "^3.0.0",
     "rename-overwrite": "^2.0.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import betterPathResolve = require('better-path-resolve')
 import fs = require('fs')
 import path = require('path')
 import makeDir = require('make-dir')
-import isWindows = require('is-windows')
 import renameOverwrite = require('rename-overwrite')
 import { promisify } from 'util'
 
@@ -10,7 +9,7 @@ const symlink = promisify(fs.symlink)
 const readlink = promisify(fs.readlink)
 const unlink = promisify(fs.unlink)
 
-const IS_WINDOWS = isWindows()
+const IS_WINDOWS = process.platform === 'win32' || /^(msys|cygwin)$/.test(<string>process.env.OSTYPE)
 
 // Always use "junctions" on Windows. Even though support for "symbolic links" was added in Vista+, users by default
 // lack permission to create them


### PR DESCRIPTION
Hello, this pull request removes the is-windows depency and replaces it by a simple one liner.

The actual function of is-windows is very and short and simple, it contains only one line (https://github.com/jonschlinkert/is-windows/blob/master/index.js#L25).

When downloading is-windows from npm, npm/yarn also downloads the LICENCE and package.json file which are much bigger than the actual wanted code, as such it's much better to directly include the function in the code than to pull in a package.

Also more packages means more risk, here's an article talking about it :  
[I’m harvesting credit card numbers and passwords from your site. Here’s how.](https://medium.com/hackernoon/im-harvesting-credit-card-numbers-and-passwords-from-your-site-here-s-how-9a8cb347c5b5)

An incident has already happened this year with the package event-stream  :
[Malicious code found in npm package event-stream downloaded 8 million times in the past 2.5 months](https://snyk.io/blog/malicious-code-found-in-npm-package-event-stream/)